### PR TITLE
Fix jagged stats

### DIFF
--- a/meals/Models/Metric.swift
+++ b/meals/Models/Metric.swift
@@ -18,3 +18,23 @@ struct MetricSample: Identifiable {
         self.value = value
     }
 }
+
+struct RelativeMetricSample: Hashable {
+    var offset: TimeInterval
+    var value: Double
+    
+    init(_ offset: TimeInterval, _ value: Double){
+        self.offset = offset
+        self.value = value
+    }
+}
+
+
+struct StatisticsBucket {
+    var index: Double
+    var min: Double
+    var max: Double
+    var percentile25: Double
+    var percentile75: Double
+    var median: Double
+}

--- a/meals/Utils/Statistics.swift
+++ b/meals/Utils/Statistics.swift
@@ -4,57 +4,69 @@
 
 import Foundation
 
+
+
 // Take a list of samples and their relative start date and a resolution
 // and calculate the percentile for each step
-func calculatePercentiles(relativeSamples: [(Date, [MetricSample])], resolution: TimeInterval) -> [StatisticsBucket] {
-    // Calculate the samples offset from their start date
-    let offsetFromDate: [(Double, Double)] = relativeSamples.flatMap { date, samples in
-        samples.map { sample in
-            (
-                    sample.date.timeIntervalSince(date) / resolution,
-                    sample.value
-            )
+func calculatePercentiles(eventSamples: [(Date, [MetricSample])], resolution: TimeInterval) -> [StatisticsBucket] {
+    let relativeSamples: [[RelativeMetricSample]] = eventSamples.map {
+        calculateRelativeSamples(eventSamples: $0)
+    }
+    
+    let roundedRelativeSamples:[RelativeMetricSample] = relativeSamples
+        .map {
+            roundToNearest(samples: $0, resolution: resolution)
+        }.flatMap {
+            $0
         }
-    }
-
+    
+    
     // Group the samples by their offset
-    let groupedByOffset = Dictionary(grouping: offsetFromDate) {
-        $0.0
+    let groupedByOffset = Dictionary(grouping: roundedRelativeSamples) {
+        $0.offset
     }
-
+    
     // Calculate the statistics
     return groupedByOffset.map { offset, samples in
-        let sorted = samples.map {
-                    $0.1
-                }
-                .sorted()
+        let sorted = samples
+            .map { $0.value }
+            .sorted()
         let min = sorted.first!
         let max = sorted.last!
         let percentile25 = sorted[Int(0.25 * Double(samples.count))]
         let percentile75 = sorted[Int(0.75 * Double(samples.count))]
-        // 1,2,3,4,5
         let middlePoint = Int(ceil(Double(sorted.count / 2)))
         let median = sorted.count % 2 == 0
-                ? (sorted[middlePoint] + sorted[middlePoint - 1]) / 2
-                : sorted[middlePoint]
+        ? (sorted[middlePoint] + sorted[middlePoint - 1]) / 2
+        : sorted[middlePoint]
+        
         return StatisticsBucket(
-                index: offset,
-                min: min,
-                max: max,
-                percentile25: percentile25,
-                percentile75: percentile75,
-                median: median
+            index: offset / resolution,
+            min: min,
+            max: max,
+            percentile25: percentile25,
+            percentile75: percentile75,
+            median: median
         )
     }.sorted(by: { $0.index < $1.index})
-
+    
 }
 
-
-struct StatisticsBucket {
-    var index: Double
-    var min: Double
-    var max: Double
-    var percentile25: Double
-    var percentile75: Double
-    var median: Double
+func calculateRelativeSamples(eventSamples: (Date, [MetricSample])) -> [RelativeMetricSample] {
+    eventSamples.1.map {
+        RelativeMetricSample(
+            $0.date.timeIntervalSince(eventSamples.0),
+            $0.value
+        )
+    }
 }
+
+func roundToNearest(samples: [RelativeMetricSample], resolution: TimeInterval) -> [RelativeMetricSample] {
+    samples.map {
+        RelativeMetricSample(
+            resolution * round($0.offset / resolution),
+            $0.value
+        )
+    }
+}
+

--- a/meals/Views/Chart/StatisticsChart.swift
+++ b/meals/Views/Chart/StatisticsChart.swift
@@ -40,7 +40,7 @@ struct StatisticsChart: UIViewRepresentable {
 
     func getModel() -> AAChartModel {
         let categories = getCategories()
-        let statisticsBuckets = calculatePercentiles(relativeSamples: samples, resolution: resolution)
+        let statisticsBuckets = calculatePercentiles(eventSamples: samples, resolution: resolution)
         let percentiles25to75 = statisticsBuckets.map {
             [$0.index, $0.percentile25, $0.percentile75]
         }
@@ -52,12 +52,14 @@ struct StatisticsChart: UIViewRepresentable {
         }
         return AAChartModel()
                 .title(title)
+                .xAxisTickInterval(2)
                 .categories(categories)
                 .colorsTheme(colors)
                 .legendEnabled(false)
+                .dataLabelsEnabled(false)
                 .series([
                     AASeriesElement()
-                            .type(.spline)
+                            .type(.line)
                             .name("median")
                             .lineWidth(0)
                             .marker(AAMarker().radius(3))

--- a/meals/Views/Meals/MealDetails.swift
+++ b/meals/Views/Meals/MealDetails.swift
@@ -180,7 +180,7 @@ struct MealDetails: View {
     
     var glucoseStatistics: some View {
         // Calculate ranges and step sizes
-        let resolution = TimeInterval(15 * 60)
+        let resolution = TimeInterval(30 * 60)
         let range = TimeInterval(hours * 60 * 60)
         let samples = glucoseSamples.map {
             $0.value


### PR DESCRIPTION
Closes #11.

The original calculation didn't round properly, so we got multiple parallel stats.

- Refactor code by separating relative sample calculation and rounding calculation
- Move structs to the models folder
- Increase resolution size for a cleaner stats look
