### PR TITLE
Enable tooltip for glucose, round samples to nearest 2 decimal points

### DIFF
--- a/meals.xcodeproj/project.pbxproj
+++ b/meals.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DF37D5E928354573007BEFE3 /* HealthKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF37D5E828354573007BEFE3 /* HealthKit.swift */; };
 		DF3D07C3282FFB8D003E36BD /* MealDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3D07C2282FFB8D003E36BD /* MealDetails.swift */; };
 		DF59D90328E2C93800A7333E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF07B3212826933800C164AB /* Preview Assets.xcassets */; };
+		DF7C9EDB290E6455000BA6C7 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7C9EDA290E6455000BA6C7 /* Math.swift */; };
 		DF8A73A028DF32C50095E9FF /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8A739F28DF32C50095E9FF /* Debug.swift */; };
 		DF8A73A228DF38E60095E9FF /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8A73A128DF38E60095E9FF /* Error.swift */; };
 		DF937573283012DA00CBE618 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF937572283012DA00CBE618 /* Event.swift */; };
@@ -88,6 +89,7 @@
 		DF282F752838C27F0044C1EF /* CornerRadiusModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusModifier.swift; sourceTree = "<group>"; };
 		DF37D5E828354573007BEFE3 /* HealthKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKit.swift; sourceTree = "<group>"; };
 		DF3D07C2282FFB8D003E36BD /* MealDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealDetails.swift; sourceTree = "<group>"; };
+		DF7C9EDA290E6455000BA6C7 /* Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		DF8A739F28DF32C50095E9FF /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
 		DF8A73A128DF38E60095E9FF /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		DF937572283012DA00CBE618 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				8FFA33E5F3EA1A6EECF0A486 /* Insulin.swift */,
 				8FFA3DBE52A31B60B727A8EF /* Statistics.swift */,
 				8FFA35F0C982E26FE8ED1FFF /* Date.swift */,
+				DF7C9EDA290E6455000BA6C7 /* Math.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 				DF07B32C2826939F00C164AB /* MealList.swift in Sources */,
 				DF12303328795D6F007156DD /* MetricStore.swift in Sources */,
 				DF9375772830137200CBE618 /* EventView.swift in Sources */,
+				DF7C9EDB290E6455000BA6C7 /* Math.swift in Sources */,
 				DF3D07C3282FFB8D003E36BD /* MealDetails.swift in Sources */,
 				DF07B31D2826933700C164AB /* ContentView.swift in Sources */,
 				DFE8D35C2840CA5400937CAB /* PhotoPicker.swift in Sources */,

--- a/meals/Utils/Math.swift
+++ b/meals/Utils/Math.swift
@@ -1,0 +1,13 @@
+//
+//  Math.swift
+//  meals
+//
+//  Created by aclowkey on 30/10/2022.
+//
+
+import Foundation
+
+func rounded(_ val: Double, toPlaces places:Int) -> Double {
+    let divisor = pow(10.0, Double(places))
+    return (val * divisor).rounded() / divisor
+}

--- a/meals/Utils/Statistics.swift
+++ b/meals/Utils/Statistics.swift
@@ -13,23 +13,22 @@ func calculatePercentiles(eventSamples: [(Date, [MetricSample])], resolution: Ti
         calculateRelativeSamples(eventSamples: $0)
     }
     
-    let roundedRelativeSamples:[RelativeMetricSample] = relativeSamples
+    let roundedIntervalRelativeSamples:[RelativeMetricSample] = relativeSamples
         .map {
-            roundToNearest(samples: $0, resolution: resolution)
+            roundToNearestInterval(samples: $0, resolution: resolution)
         }.flatMap {
             $0
         }
     
-    
     // Group the samples by their offset
-    let groupedByOffset = Dictionary(grouping: roundedRelativeSamples) {
+    let groupedByOffset = Dictionary(grouping: roundedIntervalRelativeSamples) {
         $0.offset
     }
     
     // Calculate the statistics
     return groupedByOffset.map { offset, samples in
         let sorted = samples
-            .map { $0.value }
+            .map { rounded($0.value, toPlaces: 2)}
             .sorted()
         let min = sorted.first!
         let max = sorted.last!
@@ -61,7 +60,7 @@ func calculateRelativeSamples(eventSamples: (Date, [MetricSample])) -> [Relative
     }
 }
 
-func roundToNearest(samples: [RelativeMetricSample], resolution: TimeInterval) -> [RelativeMetricSample] {
+func roundToNearestInterval(samples: [RelativeMetricSample], resolution: TimeInterval) -> [RelativeMetricSample] {
     samples.map {
         RelativeMetricSample(
             resolution * round($0.offset / resolution),

--- a/meals/Views/Chart/GlucoseChart.swift
+++ b/meals/Views/Chart/GlucoseChart.swift
@@ -47,7 +47,6 @@ struct GlucoseChart: UIViewRepresentable {
             .xAxisTickInterval(5)
             .dataLabelsEnabled(false)
             .legendEnabled(false)
-            .tooltipEnabled(false)
             .series([
                 AASeriesElement()
                     .lineWidth(0)

--- a/meals/Views/Chart/InsulinChart.swift
+++ b/meals/Views/Chart/InsulinChart.swift
@@ -55,12 +55,13 @@ struct InsulinChart: UIViewRepresentable {
     }
     
     func getData() -> [Double] {
-        samples.map { $0.value }
+        samples.map { rounded($0.value, toPlaces: 2) }
     }
     
     func getCategories() -> [String] {
         samples.map { formatTime(date: $0.date)}
     }
+    
     
     func formatTime(date: Date) -> String{
         let dateFormatter = DateFormatter()

--- a/meals/Views/Chart/InsulinStatisticsChart.swift
+++ b/meals/Views/Chart/InsulinStatisticsChart.swift
@@ -16,7 +16,8 @@ struct InsulinStatisticsChart: View {
     var samples: [(Date, [MetricSample])]
     
     var body: some View {
-        let pointCount = samples.map{$1.count}.reduce(0, +)
+        let pointCount = samples
+            .map{$1.count}.reduce(0, +)
         if pointCount > 0 {
             StatisticsChart(
                 title: "Insulin",


### PR DESCRIPTION
This PR enables tooltip for glucose and also rounds values to 2 nearest sample points.

Closes #21 
Closes #22 