### PR TITLE
Fix saving meal with a new updated at date 

### DIFF
--- a/meals/Store/MealStore.swift
+++ b/meals/Store/MealStore.swift
@@ -58,7 +58,7 @@ class MealStore: ObservableObject {
             meals.append(mealToSave)
             try JsonUtils.save(data: meals, fileName: MealStore.fileName)
         } else {
-            try updateMeal(meal: meal)
+            try updateMeal(meal: mealToSave)
         }
 
         if let image = image {


### PR DESCRIPTION
The new meal object with the correct updated at date wasn't saved. This caused stale data. 
Closes #39 